### PR TITLE
feat(db): implement soft delete for users and preserve purchases

### DIFF
--- a/App/Model/UsuarioModel.php
+++ b/App/Model/UsuarioModel.php
@@ -24,9 +24,10 @@ class UsuarioModel{
     
     /** Devuelve usuario por email (o null si no existe) */
     public function obtenerPorEmail(string $email): ?array{
+        // Se agrega "Estado = 'activo'" para evitar que usuarios inactivos puedan iniciar sesión.
         $sql = "SELECT Id, Nombre, Apellido, Email, PasswordHash, DNI, FechaNacimiento
                 FROM usuarios
-                WHERE Email = ?
+                WHERE Email = ? AND Estado = 'activo'
                 LIMIT 1";
                 
         $st = $this->db->prepare($sql);
@@ -44,6 +45,7 @@ class UsuarioModel{
     public function emailExiste(string $email): bool{
 
         // Unificada a columna Email (antes decía Correo)
+        // Se busca en todos los usuarios, activos o inactivos, para que la DB no tire error de clave única
         $sql = "SELECT 1 FROM usuarios WHERE Email = ? LIMIT 1";
         $st  = $this->db->prepare($sql);
         $st->execute([$email]);
@@ -182,7 +184,8 @@ class UsuarioModel{
     }
 
     public function findById(int $id): ?array {
-        $sql = "SELECT * FROM usuarios WHERE Id = :id LIMIT 1";
+        // Solo retornamos el usuario si está activo
+        $sql = "SELECT * FROM usuarios WHERE Id = :id AND Estado = 'activo' LIMIT 1";
         $st = $this->db->prepare($sql);
         $st->execute([':id' => $id]);
         $row = $st->fetch(\PDO::FETCH_ASSOC);
@@ -190,15 +193,11 @@ class UsuarioModel{
     }
 
     public function eliminarPorId(int $id): bool {
-        // Si tenés tablas relacionadas (recuperaciones, etc.) y NO hay FK ON DELETE CASCADE,
-        // borrá primero los registros hijos.
+        // En lugar de hacer DELETE de los registros, se usa baja lógica (soft delete).
+        // Se actualiza el estado a inactivo para no perder el historial de compras (transacciones).
         $this->db->beginTransaction();
         try {
-            // ejemplo si tuvieras tabla de recuperación:
-            // $this->db->prepare("DELETE FROM recuperaciones WHERE id_usuario = :id")
-            //          ->execute([':id' => $id]);
-
-            $ok = $this->db->prepare("DELETE FROM usuarios WHERE Id = :id")
+            $ok = $this->db->prepare("UPDATE usuarios SET Estado = 'inactivo' WHERE Id = :id")
                        ->execute([':id' => $id]);
 
             $this->db->commit();

--- a/Database/prac_prof_final.sql
+++ b/Database/prac_prof_final.sql
@@ -89,8 +89,10 @@ TRUNCATE TABLE `recuperacion_contrasena`;
 DROP TABLE IF EXISTS `transacciones`;
 CREATE TABLE IF NOT EXISTS `transacciones` (
   `ID` int(10) UNSIGNED NOT NULL AUTO_INCREMENT,
+  `id_usuario` int(10) UNSIGNED NOT NULL,
   `Momento` datetime NOT NULL DEFAULT current_timestamp(),
-  PRIMARY KEY (`ID`)
+  PRIMARY KEY (`ID`),
+  KEY `fk_tx_usuario` (`id_usuario`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 --
@@ -136,6 +138,7 @@ CREATE TABLE IF NOT EXISTS `usuarios` (
   `DNI` varchar(50) DEFAULT NULL,
   `FechaNacimiento` date DEFAULT NULL,
   `PasswordHash` varchar(255) NOT NULL,
+  `Estado` ENUM('activo', 'inactivo') NOT NULL DEFAULT 'activo',
   `CreatedAt` datetime NOT NULL DEFAULT current_timestamp(),
   `UpdatedAt` datetime DEFAULT NULL ON UPDATE current_timestamp(),
   PRIMARY KEY (`ID`),
@@ -165,6 +168,12 @@ INSERT INTO `usuarios` (`ID`, `Nombre`, `Apellido`, `Email`, `DNI`, `FechaNacimi
 --
 ALTER TABLE `recuperacion_contrasena`
   ADD CONSTRAINT `fk_recuperacion_usuario` FOREIGN KEY (`id_usuario`) REFERENCES `usuarios` (`ID`) ON DELETE CASCADE;
+
+--
+-- Filtros para la tabla `transacciones`
+--
+ALTER TABLE `transacciones`
+  ADD CONSTRAINT `fk_tx_usuario` FOREIGN KEY (`id_usuario`) REFERENCES `usuarios` (`ID`) ON UPDATE CASCADE;
 
 --
 -- Filtros para la tabla `transacciones_detalles`


### PR DESCRIPTION
This commit implements soft deletion for users to prevent the loss of their purchase history. It updates the database schema, adding a user state (`Estado`) column and explicitly mapping purchases to users via a foreign key in `transacciones`. Furthermore, login and verification paths correctly block logically deleted users.

---
*PR created automatically by Jules for task [10606961428885162625](https://jules.google.com/task/10606961428885162625) started by @iixann*